### PR TITLE
Swagger UI route

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,10 +19,10 @@ const corsOptions: CorsOptions = {
 app.use(cors(corsOptions)); 
 app.use(express.json());
 app.use(cookieParser());
+app.use('/docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
 app.use('/auth', authRouter);
 app.use('/', router);
 
-app.use('/docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
 
 app.listen(port, async () => {
   try {


### PR DESCRIPTION
Move Swagger UI route before auth middleware to allow access to API documentation without requiring login