### PR TITLE
(11) Throw error for concurrent updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # IV1201 Design of Global Applications
 
 ## Project description
-This project is the backend part of a recruitment application. The application is designed to be used by *applicants* and *recruiters*. The application allows applicants to apply for jobs and recruiters to handle applications. The backend is built using TypeScript, Node.js and the Express framework. Communication with the database is handled by Sequelize ORM and we're using a Postgres database. Developed as part of the course IV1201 Design of Global Applications at KTH. 
+
+This project is the backend part of a recruitment application. The application is designed to be used by _applicants_ and _recruiters_. The application allows applicants to apply for jobs and recruiters to handle applications. The backend is built using TypeScript, Node.js and the Express framework. Communication with the database is handled by Sequelize ORM and we're using a Postgres database. Developed as part of the course IV1201 Design of Global Applications at KTH.
 
 ## Installation
+
 1. Clone the repository
 2. Run `npm install` to install dependencies
 3. Refer to the `.env.example` file for environment variables that need to be set
@@ -11,9 +13,12 @@ This project is the backend part of a recruitment application. The application i
 5. The server will be running on `http://localhost:3000`
 
 ## Project structure
+
 The project is structured as follows:
-- `src/` 
+
+- `src/`
   - `config/` - Contains configuration files, e.g. database configuration
+  - `errors/` - Contains custom error classes
   - `controllers/` - Contains the controllers that handle requests
   - `docs/` - Contains setup for serving the OpenAPI documentation
   - `models/` - Contains the Sequelize models and DTOs
@@ -21,6 +26,7 @@ The project is structured as follows:
   - `services/` - Contains the services that handle business logic
   - `repositories/` - Contains the repositories that handle database queries
 - `__tests__/` - Contains tests
+
 ---
 
 In short, all endpoints are defined in the `routes` directory. The routes are mapped to controllers which in turn call services. The services handle the business logic and call the repositories which handle the database queries. The models directory contains the Sequelize models and DTOs.
@@ -28,15 +34,19 @@ In short, all endpoints are defined in the `routes` directory. The routes are ma
 ## Documentation
 
 ### API documentation
+
 The API is documented using OpenAPI (formerly Swagger) and is viewable in a nice UI at `http://localhost:3000/docs` when the server is running.
 
 ### General documentation
+
 Function parameters, return types and other general type documentation is mainly covered by TypeScript but also JSDoc comments.
 
 ---
 
 ## Testing
+
 The project uses Jest for testing. Run `npm test` to run the tests. Tests are located in the `__tests__` directory.
 
 ## CI/CD
+
 The project uses GitHub Actions for CI/CD. The starting point and main workflow is defined in `.github/workflows/main.yml`. The workflow runs tests and linters on every push and are required to pass to allow pushing to `main`.

--- a/src/errors/ConflictError.ts
+++ b/src/errors/ConflictError.ts
@@ -1,0 +1,6 @@
+export class ConflictError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ConflictError';
+  }
+}

--- a/src/models/Application.ts
+++ b/src/models/Application.ts
@@ -11,7 +11,7 @@ class Application extends Model {
 
   // Associations
   declare person?: Person;
-  declare status?: Status;
+  declare status: Status;
 }
 
 Application.init(

--- a/src/models/ApplicationDetailsDTO.ts
+++ b/src/models/ApplicationDetailsDTO.ts
@@ -11,18 +11,21 @@ export class ApplicationDetailsDTO {
   competence: CompetenceProfileDTO[];
   availability: AvailabilityDTO[];
   status: string;
+  status_id: number;
 
   constructor(
     application_id: number,
     person: PersonDTO,
     competence: CompetenceProfileDTO[],
     availability: AvailabilityDTO[],
-    status: string = 'unhandled'
+    status: string = 'unhandled',
+    status_id: number
   ) {
     this.application_id = application_id;
     this.person = person;
     this.competence = competence;
     this.availability = availability;
     this.status = status;
+    this.status_id = status_id;
   }
 }

--- a/src/repositories/ApplicationRepository.ts
+++ b/src/repositories/ApplicationRepository.ts
@@ -1,14 +1,12 @@
-
-import Application from "../models/Application";
-import { Person, Status } from "../models";
-import { IApplicationRepository } from "./contracts/IApplicationRepository";
-import { ApplicationDTO } from "../models/ApplicationDTO";
-import { PersonRepository } from "./PersonRepository";
-import { AvailabilityRepository } from "./AvailabilityRepository";
-import { CompetenceProfileRepository } from "./CompetenceProfileRepository";
-import { ApplicationDetailsDTO } from "../models/ApplicationDetailsDTO";
-import { Validators } from "../util/validator";
-
+import Application from '../models/Application';
+import { Person, Status } from '../models';
+import { IApplicationRepository } from './contracts/IApplicationRepository';
+import { ApplicationDTO } from '../models/ApplicationDTO';
+import { PersonRepository } from './PersonRepository';
+import { AvailabilityRepository } from './AvailabilityRepository';
+import { CompetenceProfileRepository } from './CompetenceProfileRepository';
+import { ApplicationDetailsDTO } from '../models/ApplicationDetailsDTO';
+import { Validators } from '../util/validator';
 
 /**
  * Repository class for handling application-related database operations
@@ -45,56 +43,60 @@ export class ApplicationRepository implements IApplicationRepository {
         )
     );
     return applicationsDTO;
-
-  };
-
- /**
-  * Retrieves detailed information about a specific application
-  * @param {number} application_id - The ID of the application to retrieve details for
-  * @returns {Promise<ApplicationDetailsDTO>} A promise that resolves with the application details
-  */
-  async getApplicationDetailsById(application_id : number){
-      try{
-        Validators.isValidId(application_id, "application_id");
-        const personRepo = new PersonRepository();
-        const availabilityRepo = new AvailabilityRepository();
-        const competenceRepo = new CompetenceProfileRepository();
-
-        const application = await Application.findByPk(application_id, {
-          include: [
-            { model: Status, attributes: ['status_name'] }
-          ],
-          attributes: ['application_id', 'person_id', 'status_id']
-        });
-
-
-          if (!application) {
-            throw new Error(`Application details not found for application_id: ${application_id}`);
-        }
-          
-          const person = await personRepo.getUserDetailById(application.person_id);
-          if(!person){
-            throw new Error(`Person not found for person_id: ${application.person_id} in application: ${application_id}`);
-          }
-          const competences = await competenceRepo.getCompetenceProfileById(application.person_id); 
-          const availabilities = await availabilityRepo.getAllAvailabilyById(application.person_id);
-
-          const applicationDetail : ApplicationDetailsDTO = new ApplicationDetailsDTO(
-            application_id,
-            person,
-            competences,
-            availabilities,
-            application!.status?.status_name
-          );
-
-          return applicationDetail;
-      }catch(error){
-       console.log(" error fetching",error);
-       throw error;
-    }
   }
 
+  /**
+   * Retrieves detailed information about a specific application
+   * @param {number} application_id - The ID of the application to retrieve details for
+   * @returns {Promise<ApplicationDetailsDTO>} A promise that resolves with the application details
+   */
+  async getApplicationDetailsById(application_id: number) {
+    try {
+      Validators.isValidId(application_id, 'application_id');
+      const personRepo = new PersonRepository();
+      const availabilityRepo = new AvailabilityRepository();
+      const competenceRepo = new CompetenceProfileRepository();
 
+      const application = await Application.findByPk(application_id, {
+        include: [{ model: Status, attributes: ['status_name', 'status_id'] }],
+        attributes: ['application_id', 'person_id', 'status_id']
+      });
+
+      if (!application) {
+        throw new Error(
+          `Application details not found for application_id: ${application_id}`
+        );
+      }
+
+      const person = await personRepo.getUserDetailById(application.person_id);
+      if (!person) {
+        throw new Error(
+          `Person not found for person_id: ${application.person_id} in application: ${application_id}`
+        );
+      }
+      const competences = await competenceRepo.getCompetenceProfileById(
+        application.person_id
+      );
+      const availabilities = await availabilityRepo.getAllAvailabilyById(
+        application.person_id
+      );
+
+      const applicationDetail: ApplicationDetailsDTO =
+        new ApplicationDetailsDTO(
+          application_id,
+          person,
+          competences,
+          availabilities,
+          application!.status?.status_name,
+          application.status?.status_id
+        );
+
+      return applicationDetail;
+    } catch (error) {
+      console.log(' error fetching', error);
+      throw error;
+    }
+  }
 
   /**
    * Updates the status of an application
@@ -102,11 +104,10 @@ export class ApplicationRepository implements IApplicationRepository {
    * @param {number} new_status_id - The new status ID to set
    * @returns {Promise} A promise that resolves when the status is updated
    */
-  async updateApplicationStatus(application_id : number, new_status_id : number){
-
-    try{
-      Validators.isValidId(application_id, "application_id");
-      Validators.isValidId(new_status_id, "status_id");
+  async updateApplicationStatus(application_id: number, new_status_id: number) {
+    try {
+      Validators.isValidId(application_id, 'application_id');
+      Validators.isValidId(new_status_id, 'status_id');
 
       const [updatedCount, updatedRows] = await Application.update(
         { status_id: new_status_id },
@@ -139,9 +140,9 @@ export class ApplicationRepository implements IApplicationRepository {
   ) {
     try {
       // Check if an application already exists for this person
-      Validators.isValidId(person_id, "person_id");
-      const existingApplication = await Application.findOne({ 
-        where: { person_id } 
+      Validators.isValidId(person_id, 'person_id');
+      const existingApplication = await Application.findOne({
+        where: { person_id }
       });
 
       if (existingApplication) {

--- a/src/routes/routes.ts
+++ b/src/routes/routes.ts
@@ -66,9 +66,12 @@ router.get(
  *            schema:
  *              type: object
  *              properties:
- *                status:
+ *                new_status_id:
  *                  type: integer
  *                  description: The new status_id for the application
+ *                old_status_id:
+ *                  type: integer
+ *                  description: The old status_id for the application
  *      responses:
  *        200:
  *          description: Application status updated successfully
@@ -76,6 +79,8 @@ router.get(
  *          description: Unauthorized access
  *        404:
  *          description: Application not found
+ *        409:
+ *          description: Application updated by other user
  */
 router.put(
   '/applications/:application_id/status',

--- a/src/services/ApplicationService.ts
+++ b/src/services/ApplicationService.ts
@@ -1,4 +1,5 @@
 import { IApplicationRepository } from '../repositories/contracts/IApplicationRepository';
+import { ConflictError } from '../errors/ConflictError';
 
 /**
  * Service class for handling application-related operations
@@ -43,10 +44,24 @@ export class ApplicationService {
    * Updates the status of an application
    * @param {number} application_id - The ID of the application to update
    * @param {number} new_status_id - The new status ID to set for the application
+   * @param {number} old_status_id - The old status ID to check before updating
    * @returns {Promise} A promise that resolves when the status is updated
    */
-  async updateApplicationStatus(application_id: number, new_status_id: number) {
+  async updateApplicationStatus(
+    application_id: number,
+    new_status_id: number,
+    old_status_id: number
+  ) {
     try {
+      const currentApplication =
+        await this.applicationRepository.getApplicationDetailsById(
+          application_id
+        );
+      if (currentApplication?.status_id !== old_status_id) {
+        throw new ConflictError(
+          `Application was updated by another user. Please refresh and try again.`
+        );
+      }
       return await this.applicationRepository.updateApplicationStatus(
         application_id,
         new_status_id


### PR DESCRIPTION
Requirement 11:
> Implement alternative flow 2a in use case 5.5,
Show Application. The scenario is that two users list the
same application simultaneously, then user one updates
the status (for example to accepted), and finally user two
also updates the status. Now user two will overwrite user
one’s update, without even knowing that user one made an
update. In this case, the application must instead abort
the update and inform user two why it was aborted.

This is solved by sending both "old" and "new" status id and at the server compare the old status with the currently stored one in the database and throw an error if they're not the same